### PR TITLE
Add dynamic SPA frontend

### DIFF
--- a/frontend/assets/app.js
+++ b/frontend/assets/app.js
@@ -1,0 +1,727 @@
+const loginView = document.getElementById('login-view');
+const appView = document.getElementById('app-view');
+const loginForm = document.getElementById('login-form');
+const loginFeedback = document.getElementById('login-feedback');
+const sessionInfo = document.getElementById('session-info');
+const toastContainer = document.getElementById('toast-container');
+const logoutBtn = document.getElementById('logout-btn');
+const refreshAllBtn = document.getElementById('refresh-all');
+const routerVendorSelect = document.getElementById('router-vendor');
+const routerForm = document.getElementById('router-form');
+const snmpTestForm = document.getElementById('snmp-test-form');
+const snmpTestResult = document.getElementById('snmp-test-result');
+const routersTable = document.querySelector('#routers-table tbody');
+const alertsTable = document.querySelector('#alerts-table tbody');
+const alertForm = document.getElementById('alert-form');
+const configView = document.getElementById('config-view');
+const configEditor = document.getElementById('config-editor');
+const configFeedback = document.getElementById('config-feedback');
+const whitelistView = document.getElementById('whitelist-view');
+const whitelistEditor = document.getElementById('whitelist-editor');
+const whitelistFeedback = document.getElementById('whitelist-feedback');
+const firewallStatus = document.getElementById('firewall-status');
+const grafanaList = document.getElementById('grafana-list');
+const bgpTable = document.querySelector('#bgp-table tbody');
+const interfacesTable = document.querySelector('#interfaces-table tbody');
+const flowsTable = document.querySelector('#flows-table tbody');
+const flowLimitInput = document.getElementById('flow-limit');
+const systemCards = document.getElementById('system-cards');
+const statsOverview = document.getElementById('stats-overview');
+const topSourcesTable = document.querySelector('#top-sources-table tbody');
+const topAppsTable = document.querySelector('#top-apps-table tbody');
+
+let sessionCache = null;
+let vendorsCache = [];
+
+function showToast(message, variant = 'info') {
+    const wrapper = document.createElement('div');
+    wrapper.className = `toast text-bg-${variant}`;
+    wrapper.setAttribute('role', 'alert');
+    wrapper.innerHTML = `
+        <div class="d-flex">
+            <div class="toast-body">${message}</div>
+            <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+        </div>
+    `;
+    toastContainer.appendChild(wrapper);
+    const toast = new bootstrap.Toast(wrapper, { delay: 4000 });
+    toast.show();
+    wrapper.addEventListener('hidden.bs.toast', () => wrapper.remove());
+}
+
+async function apiFetch(path, options = {}) {
+    const opts = { method: 'GET', credentials: 'include', ...options };
+    opts.headers = { Accept: 'application/json', ...(options.headers || {}) };
+    if (options.json !== undefined) {
+        opts.body = JSON.stringify(options.json);
+        opts.headers['Content-Type'] = 'application/json';
+    }
+    const response = await fetch(path, opts);
+    if (!response.ok) {
+        let detail = '';
+        try {
+            const data = await response.json();
+            detail = data.error || JSON.stringify(data);
+        } catch (_) {
+            detail = await response.text();
+        }
+        throw new Error(detail || response.statusText);
+    }
+    if (response.status === 204) {
+        return null;
+    }
+    const contentType = response.headers.get('content-type') || '';
+    if (contentType.includes('application/json')) {
+        return response.json();
+    }
+    return response.text();
+}
+
+function formatBytes(bytes) {
+    if (!Number.isFinite(bytes)) return '-';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+    let value = bytes;
+    let unit = 0;
+    while (value >= 1024 && unit < units.length - 1) {
+        value /= 1024;
+        unit += 1;
+    }
+    return `${value.toFixed(value >= 10 || value % 1 === 0 ? 0 : 1)} ${units[unit]}`;
+}
+
+function formatPercent(value, fractionDigits = 1) {
+    if (!Number.isFinite(value)) return '-';
+    return `${value.toFixed(fractionDigits)}%`;
+}
+
+function formatNumber(value) {
+    if (!Number.isFinite(value)) return '-';
+    return value.toLocaleString('pt-BR');
+}
+
+function formatDate(value) {
+    if (!value) return '-';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value;
+    return date.toLocaleString('pt-BR');
+}
+
+function showLogin(message) {
+    if (message) {
+        loginFeedback.textContent = message;
+        loginFeedback.classList.add('text-danger');
+    } else {
+        loginFeedback.textContent = '';
+        loginFeedback.classList.remove('text-danger');
+    }
+    loginView.classList.remove('d-none');
+    appView.classList.add('d-none');
+}
+
+function showApp() {
+    loginView.classList.add('d-none');
+    appView.classList.remove('d-none');
+}
+
+async function checkSession() {
+    try {
+        const data = await apiFetch('/api/session');
+        sessionCache = data;
+        renderSession();
+        showApp();
+        await Promise.all([
+            loadVendors(),
+            loadDashboard(),
+            loadConfig(),
+            loadWhitelist(),
+            loadFirewallStatus(),
+            loadGrafana(),
+        ]);
+    } catch (error) {
+        sessionCache = null;
+        showLogin(error.message.includes('token') ? 'Sessão expirada, realize login novamente.' : 'Autentique-se para continuar.');
+    }
+}
+
+function renderSession() {
+    if (!sessionCache) return;
+    const expires = sessionCache.expires_at ? formatDate(sessionCache.expires_at) : 'Sessão ativa';
+    sessionInfo.textContent = `Usuário: ${sessionCache.user} • Iniciado: ${formatDate(sessionCache.started_at)} • Expira: ${expires}`;
+}
+
+loginForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const user = document.getElementById('login-user').value.trim();
+    const pass = document.getElementById('login-pass').value;
+    if (!user || !pass) {
+        loginFeedback.textContent = 'Informe usuário e senha.';
+        loginFeedback.classList.add('text-danger');
+        return;
+    }
+    loginFeedback.textContent = 'Autenticando...';
+    loginFeedback.classList.remove('text-danger');
+    try {
+        await apiFetch('/api/login', { method: 'POST', json: { user, pass } });
+        loginFeedback.textContent = '';
+        showToast('Login realizado com sucesso.', 'success');
+        await checkSession();
+    } catch (error) {
+        loginFeedback.textContent = error.message || 'Falha ao autenticar';
+        loginFeedback.classList.add('text-danger');
+    }
+});
+
+logoutBtn.addEventListener('click', async () => {
+    try {
+        await apiFetch('/api/logout', { method: 'POST' });
+    } catch (_) {
+        // ignore
+    }
+    sessionCache = null;
+    showLogin('Sessão finalizada.');
+});
+
+refreshAllBtn.addEventListener('click', async () => {
+    try {
+        await Promise.all([
+            loadDashboard(),
+            loadRouters(),
+            loadAlerts(),
+            loadConfig(),
+            loadWhitelist(),
+            loadFirewallStatus(),
+            loadGrafana(),
+            loadBGPPeers(),
+            loadInterfaces(),
+            loadFlows(),
+        ]);
+        showToast('Dados atualizados.', 'success');
+    } catch (error) {
+        showToast(`Nem todos os dados foram atualizados: ${error.message}`, 'danger');
+    }
+});
+
+async function loadVendors() {
+    try {
+        vendorsCache = await apiFetch('/api/vendors');
+        routerVendorSelect.innerHTML = vendorsCache.map((vendor) => `<option value="${vendor}">${vendor}</option>`).join('');
+    } catch (error) {
+        showToast(`Falha ao carregar vendors: ${error.message}`, 'danger');
+    }
+}
+
+async function loadDashboard() {
+    await Promise.all([loadSystemStatus(), loadStats(), loadDashboardStats()]);
+}
+
+async function loadSystemStatus() {
+    try {
+        const data = await apiFetch('/api/system');
+        renderSystemCards(data);
+    } catch (error) {
+        showToast(`Erro ao buscar status do sistema: ${error.message}`, 'danger');
+    }
+}
+
+function renderSystemCards(data) {
+    if (!data) return;
+    const cards = [];
+    cards.push({
+        title: 'Uso de CPU',
+        icon: 'microchip',
+        value: formatPercent(data.cpu || 0),
+        footer: `${data.cores?.length || 0} núcleos monitorados`,
+    });
+    cards.push({
+        title: 'Memória',
+        icon: 'memory',
+        value: `${formatBytes((data.mem?.used_gb || 0) * 1024 ** 3)} / ${formatBytes((data.mem?.total_gb || 0) * 1024 ** 3)}`,
+        footer: formatPercent(((data.mem?.used_gb || 0) / (data.mem?.total_gb || 1)) * 100),
+    });
+    cards.push({
+        title: 'Armazenamento',
+        icon: 'hard-drive',
+        value: `${formatBytes((data.disk?.used_gb || 0) * 1024 ** 3)} / ${formatBytes((data.disk?.total_gb || 0) * 1024 ** 3)}`,
+        footer: formatPercent(((data.disk?.used_gb || 0) / (data.disk?.total_gb || 1)) * 100),
+    });
+    cards.push({
+        title: 'Uptime',
+        icon: 'clock',
+        value: data.host?.uptime || '-',
+        footer: `Hardware ID: ${data.host?.hwid || '-'}`,
+    });
+    systemCards.innerHTML = cards
+        .map(
+            (card) => `
+            <div class="col-md-6 col-xl-3">
+                <div class="card h-100">
+                    <div class="card-body">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <span class="text-secondary">${card.title}</span>
+                            <i class="fa-solid fa-${card.icon} text-primary"></i>
+                        </div>
+                        <p class="fs-4 fw-semibold mt-2">${card.value}</p>
+                        <p class="text-secondary mb-0">${card.footer}</p>
+                    </div>
+                </div>
+            </div>`
+        )
+        .join('');
+}
+
+async function loadStats() {
+    try {
+        const data = await apiFetch('/stats');
+        const entries = {
+            'Fluxos processados': formatNumber(data.flows_processed),
+            'Erros de fluxo': formatNumber(data.flow_errors),
+            'Erros SNMP': formatNumber(data.snmp_errors),
+            'Fluxos ativos': formatNumber(data.active_flows),
+            'Fila de processamento': formatNumber(data.queue_length),
+            'Interfaces monitoradas': formatNumber(data.interface_count),
+            'Goroutines': formatNumber(data.goroutines),
+        };
+        statsOverview.innerHTML = Object.entries(entries)
+            .map(
+                ([label, value]) => `
+                <dt class="col-7">${label}</dt>
+                <dd class="col-5 text-end fw-semibold">${value}</dd>`
+            )
+            .join('');
+    } catch (error) {
+        showToast(`Erro ao buscar estatísticas: ${error.message}`, 'danger');
+    }
+}
+
+async function loadDashboardStats() {
+    try {
+        const data = await apiFetch('/api/dashboard/stats');
+        const sourcesRows = (data.top_sources || [])
+            .map(
+                (item) => `
+                <tr>
+                    <td>${item.source_name}</td>
+                    <td>${item.vendor || '-'}</td>
+                    <td>${formatBytes(item.total_bytes)}</td>
+                    <td>${formatPercent(item.percentage || 0)}</td>
+                </tr>`
+            )
+            .join('');
+        topSourcesTable.innerHTML = sourcesRows || '<tr><td colspan="4" class="text-center text-secondary">Nenhum dado.</td></tr>';
+
+        const appsRows = (data.top_applications || [])
+            .map(
+                (item) => `
+                <tr>
+                    <td>${item.protocol}</td>
+                    <td>${item.port}</td>
+                    <td>${formatBytes(item.total_bytes)}</td>
+                </tr>`
+            )
+            .join('');
+        topAppsTable.innerHTML = appsRows || '<tr><td colspan="3" class="text-center text-secondary">Nenhum dado.</td></tr>';
+    } catch (error) {
+        showToast(`Erro ao buscar dados do dashboard: ${error.message}`, 'danger');
+    }
+}
+
+async function loadRouters() {
+    try {
+        const routers = await apiFetch('/api/routers');
+        if (!Array.isArray(routers) || routers.length === 0) {
+            routersTable.innerHTML = '<tr><td colspan="5" class="text-center text-secondary">Nenhum roteador cadastrado.</td></tr>';
+            return;
+        }
+        routersTable.innerHTML = routers
+            .map((router) => {
+                const snmp = router.snmp || {};
+                return `
+                <tr>
+                    <td>${router.name}</td>
+                    <td>${router.vendor}</td>
+                    <td>${snmp.ip || '-'}</td>
+                    <td>v${snmp.version || '-'} @ ${snmp.port || 161}</td>
+                    <td class="text-nowrap">
+                        <button class="btn btn-sm btn-outline-light me-1" data-action="edit-router" data-name="${encodeURIComponent(router.name)}">
+                            <i class="fa-solid fa-pen"></i>
+                        </button>
+                        <button class="btn btn-sm btn-outline-danger" data-action="delete-router" data-name="${encodeURIComponent(router.name)}">
+                            <i class="fa-solid fa-trash"></i>
+                        </button>
+                    </td>
+                </tr>`;
+            })
+            .join('');
+    } catch (error) {
+        showToast(`Erro ao carregar roteadores: ${error.message}`, 'danger');
+    }
+}
+
+document.getElementById('reload-routers').addEventListener('click', loadRouters);
+
+routersTable.addEventListener('click', async (event) => {
+    const button = event.target.closest('button[data-action]');
+    if (!button) return;
+    const action = button.dataset.action;
+    const name = decodeURIComponent(button.dataset.name || '');
+    if (!name) return;
+
+    if (action === 'delete-router') {
+        if (!confirm(`Confirma remover o roteador ${name}?`)) return;
+        try {
+            await apiFetch(`/api/routers/${encodeURIComponent(name)}`, { method: 'DELETE' });
+            showToast('Roteador removido.', 'success');
+            await loadRouters();
+        } catch (error) {
+            showToast(`Falha ao remover: ${error.message}`, 'danger');
+        }
+    }
+
+    if (action === 'edit-router') {
+        try {
+            const current = await apiFetch(`/api/routers/${encodeURIComponent(name)}`);
+            const updatedText = prompt('Edite o JSON do roteador:', JSON.stringify(current, null, 2));
+            if (!updatedText) return;
+            const payload = JSON.parse(updatedText);
+            await apiFetch(`/api/routers/${encodeURIComponent(name)}`, { method: 'PUT', json: payload });
+            showToast('Roteador atualizado.', 'success');
+            await loadRouters();
+        } catch (error) {
+            showToast(`Falha ao atualizar: ${error.message}`, 'danger');
+        }
+    }
+});
+
+routerForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const payload = {
+        name: document.getElementById('router-name').value.trim(),
+        vendor: document.getElementById('router-vendor').value,
+        snmp: {
+            ip: document.getElementById('router-ip').value.trim(),
+            community: document.getElementById('router-community').value.trim() || 'public',
+            port: Number(document.getElementById('router-port').value) || 161,
+            version: document.getElementById('router-version').value,
+        },
+    };
+    if (!payload.name || !payload.snmp.ip) {
+        showToast('Informe nome e IP do roteador.', 'warning');
+        return;
+    }
+    try {
+        await apiFetch('/api/routers', { method: 'POST', json: payload });
+        routerForm.reset();
+        document.getElementById('router-community').value = 'public';
+        document.getElementById('router-port').value = 161;
+        showToast('Roteador cadastrado.', 'success');
+        await loadRouters();
+    } catch (error) {
+        showToast(`Falha ao cadastrar: ${error.message}`, 'danger');
+    }
+});
+
+snmpTestForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const payload = {
+        ip: document.getElementById('snmp-test-ip').value.trim(),
+        community: document.getElementById('snmp-test-community').value.trim() || 'public',
+        port: Number(document.getElementById('snmp-test-port').value) || 161,
+        version: '2c',
+    };
+    snmpTestResult.textContent = 'Executando teste...';
+    snmpTestResult.classList.remove('text-danger');
+    try {
+        const response = await apiFetch('/api/snmp/test', { method: 'POST', json: payload });
+        snmpTestResult.textContent = `${response.message} (${response.description || 'sem descrição'})`;
+    } catch (error) {
+        snmpTestResult.textContent = error.message;
+        snmpTestResult.classList.add('text-danger');
+    }
+});
+
+async function loadAlerts() {
+    try {
+        const alerts = await apiFetch('/api/alerts');
+        if (!Array.isArray(alerts) || alerts.length === 0) {
+            alertsTable.innerHTML = '<tr><td colspan="4" class="text-center text-secondary">Nenhuma regra configurada.</td></tr>';
+            return;
+        }
+        alertsTable.innerHTML = alerts
+            .map((rule) => `
+                <tr>
+                    <td>${rule.name}</td>
+                    <td>${rule.enabled ? '<span class="badge bg-success">Ativo</span>' : '<span class="badge bg-secondary">Inativo</span>'}</td>
+                    <td><code>${rule.filter || '-'}</code></td>
+                    <td class="text-nowrap">
+                        <button class="btn btn-sm btn-outline-light me-1" data-action="edit-alert" data-name="${encodeURIComponent(rule.name)}">
+                            <i class="fa-solid fa-pen"></i>
+                        </button>
+                        <button class="btn btn-sm btn-outline-danger" data-action="delete-alert" data-name="${encodeURIComponent(rule.name)}">
+                            <i class="fa-solid fa-trash"></i>
+                        </button>
+                    </td>
+                </tr>`)
+            .join('');
+    } catch (error) {
+        showToast(`Falha ao carregar alertas: ${error.message}`, 'danger');
+    }
+}
+
+document.getElementById('reload-alerts').addEventListener('click', loadAlerts);
+
+alertsTable.addEventListener('click', async (event) => {
+    const button = event.target.closest('button[data-action]');
+    if (!button) return;
+    const action = button.dataset.action;
+    const name = decodeURIComponent(button.dataset.name || '');
+    if (!name) return;
+
+    if (action === 'delete-alert') {
+        if (!confirm(`Deseja remover a regra ${name}?`)) return;
+        try {
+            await apiFetch(`/api/alerts/${encodeURIComponent(name)}`, { method: 'DELETE' });
+            showToast('Regra removida.', 'success');
+            await loadAlerts();
+        } catch (error) {
+            showToast(`Falha ao remover: ${error.message}`, 'danger');
+        }
+    }
+
+    if (action === 'edit-alert') {
+        try {
+            const alerts = await apiFetch('/api/alerts');
+            const current = alerts.find((item) => item.name === name);
+            if (!current) {
+                showToast('Regra não encontrada.', 'warning');
+                return;
+            }
+            const updated = prompt('Atualize o JSON da regra:', JSON.stringify(current, null, 2));
+            if (!updated) return;
+            const payload = JSON.parse(updated);
+            await apiFetch(`/api/alerts/${encodeURIComponent(name)}`, { method: 'PUT', json: payload });
+            showToast('Regra atualizada.', 'success');
+            await loadAlerts();
+        } catch (error) {
+            showToast(`Falha ao atualizar: ${error.message}`, 'danger');
+        }
+    }
+});
+
+alertForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const payload = {
+        name: document.getElementById('alert-name').value.trim(),
+        filter: document.getElementById('alert-filter').value.trim(),
+        condition: document.getElementById('alert-condition').value.trim(),
+        time_window_seconds: Number(document.getElementById('alert-window').value) || 60,
+        actions: document.getElementById('alert-actions').value.split(',').map((item) => item.trim()).filter(Boolean),
+        comment: document.getElementById('alert-comment').value.trim(),
+        enabled: document.getElementById('alert-enabled').checked,
+    };
+    try {
+        await apiFetch('/api/alerts', { method: 'POST', json: payload });
+        alertForm.reset();
+        document.getElementById('alert-window').value = 60;
+        document.getElementById('alert-enabled').checked = true;
+        showToast('Regra criada com sucesso.', 'success');
+        await loadAlerts();
+    } catch (error) {
+        showToast(`Falha ao criar regra: ${error.message}`, 'danger');
+    }
+});
+
+async function loadConfig() {
+    try {
+        const cfg = await apiFetch('/api/config');
+        configView.textContent = JSON.stringify(cfg, null, 2);
+    } catch (error) {
+        showToast(`Erro ao carregar configuração: ${error.message}`, 'danger');
+    }
+}
+
+document.getElementById('reload-config').addEventListener('click', loadConfig);
+
+document.getElementById('save-config').addEventListener('click', async () => {
+    if (!configEditor.value.trim()) {
+        configFeedback.textContent = 'Informe um JSON para atualizar.';
+        configFeedback.classList.add('text-danger');
+        return;
+    }
+    try {
+        const payload = JSON.parse(configEditor.value);
+        const response = await apiFetch('/api/config', { method: 'PUT', json: payload });
+        configView.textContent = JSON.stringify(response, null, 2);
+        configFeedback.textContent = 'Configuração aplicada com sucesso.';
+        configFeedback.classList.remove('text-danger');
+        showToast('Configuração atualizada.', 'success');
+    } catch (error) {
+        configFeedback.textContent = error.message;
+        configFeedback.classList.add('text-danger');
+    }
+});
+
+async function loadWhitelist() {
+    try {
+        const data = await apiFetch('/api/whitelist');
+        whitelistView.textContent = JSON.stringify(data, null, 2);
+    } catch (error) {
+        showToast(`Erro ao carregar whitelist: ${error.message}`, 'danger');
+    }
+}
+
+document.getElementById('save-whitelist').addEventListener('click', async () => {
+    try {
+        const payload = whitelistEditor.value.trim() ? JSON.parse(whitelistEditor.value) : { ips: [], cidrs: [] };
+        await apiFetch('/api/whitelist', { method: 'PUT', json: payload });
+        whitelistFeedback.textContent = 'Whitelist salva com sucesso.';
+        whitelistFeedback.classList.remove('text-danger');
+        showToast('Whitelist atualizada.', 'success');
+        await loadWhitelist();
+    } catch (error) {
+        whitelistFeedback.textContent = error.message;
+        whitelistFeedback.classList.add('text-danger');
+    }
+});
+
+async function loadFirewallStatus() {
+    try {
+        const data = await apiFetch('/api/firewall/status');
+        const entries = {
+            Backend: data.backend,
+            'Backends disponíveis': (data.available_backends || []).join(', ') || 'Nenhum',
+            Detalhes: data.detail || '-'
+        };
+        firewallStatus.innerHTML = Object.entries(entries)
+            .map(
+                ([label, value]) => `
+                <dt class="col-4">${label}</dt>
+                <dd class="col-8">${value}</dd>`
+            )
+            .join('');
+    } catch (error) {
+        showToast(`Erro ao buscar status do firewall: ${error.message}`, 'danger');
+    }
+}
+
+async function loadGrafana() {
+    try {
+        const dashboards = await apiFetch('/api/grafana/dashboards');
+        grafanaList.innerHTML = dashboards.length
+            ? dashboards
+                  .map(
+                      (item) => `
+                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                        <span>${item.name}</span>
+                        <span class="badge bg-secondary">${formatBytes(item.size || 0)}</span>
+                    </li>`
+                  )
+                  .join('')
+            : '<li class="list-group-item">Nenhum dashboard cadastrado.</li>';
+    } catch (error) {
+        showToast(`Erro ao carregar dashboards: ${error.message}`, 'danger');
+    }
+}
+
+Array.from(document.querySelectorAll('#tab-management [data-action]')).forEach((button) => {
+    button.addEventListener('click', async () => {
+        const action = button.dataset.action;
+        try {
+            const response = await apiFetch(action, { method: 'POST' });
+            showToast(response.message || 'Ação executada.', 'success');
+        } catch (error) {
+            showToast(`Falha ao executar ação: ${error.message}`, 'danger');
+        }
+    });
+});
+
+async function loadBGPPeers() {
+    try {
+        const peers = await apiFetch('/api/bgp/peers');
+        bgpTable.innerHTML = peers.length
+            ? peers
+                  .map(
+                      (peer) => `
+                    <tr>
+                        <td>${peer.source_name}</td>
+                        <td>${peer.peer_ip}</td>
+                        <td>${peer.remote_as || '-'}</td>
+                        <td>${peer.state || peer.admin_status || '-'}</td>
+                    </tr>`
+                  )
+                  .join('')
+            : '<tr><td colspan="4" class="text-center text-secondary">Nenhum peer disponível.</td></tr>';
+    } catch (error) {
+        showToast(`Erro ao carregar peers BGP: ${error.message}`, 'danger');
+    }
+}
+
+async function loadInterfaces() {
+    try {
+        const data = await apiFetch('/api/interfaces');
+        const rows = [];
+        Object.entries(data || {}).forEach(([device, info]) => {
+            const vendor = info.vendor || '-';
+            const ifaceMap = info.interfaces || {};
+            Object.values(ifaceMap).forEach((iface) => {
+                rows.push(`
+                    <tr>
+                        <td>${device} <small class="text-secondary">(${vendor})</small></td>
+                        <td>${iface.snmp_name || iface.name || '-'}</td>
+                        <td>${iface.snmp_desc || iface.desc || '-'}</td>
+                    </tr>`);
+            });
+        });
+        interfacesTable.innerHTML = rows.length
+            ? rows.join('')
+            : '<tr><td colspan="3" class="text-center text-secondary">Nenhuma interface conhecida.</td></tr>';
+    } catch (error) {
+        showToast(`Erro ao carregar interfaces: ${error.message}`, 'danger');
+    }
+}
+
+async function loadFlows() {
+    try {
+        const limit = Number(flowLimitInput.value) || 20;
+        const flows = await apiFetch(`/flows?limit=${limit}`);
+        flowsTable.innerHTML = flows.length
+            ? flows
+                  .map(
+                      (flow) => `
+                    <tr>
+                        <td>${flow.SourceName || '-'}</td>
+                        <td>${flow.SrcAddr} → ${flow.DstAddr}</td>
+                        <td>${flow.Proto}/${flow.DstPort}</td>
+                        <td>${formatBytes(flow.Bytes)}</td>
+                        <td>${formatDate(flow.TimeReceived)}</td>
+                    </tr>`
+                  )
+                  .join('')
+            : '<tr><td colspan="5" class="text-center text-secondary">Nenhum flow encontrado.</td></tr>';
+    } catch (error) {
+        showToast(`Erro ao carregar flows: ${error.message}`, 'danger');
+    }
+}
+
+flowLimitInput.addEventListener('change', () => {
+    loadFlows();
+});
+
+const tabLoaders = new Map([
+    ['#tab-dashboard', loadDashboard],
+    ['#tab-routers', async () => { await loadRouters(); await loadBGPPeers(); }],
+    ['#tab-alerts', loadAlerts],
+    ['#tab-config', loadConfig],
+    ['#tab-whitelist', async () => { await loadWhitelist(); await loadFirewallStatus(); }],
+    ['#tab-management', async () => { await loadGrafana(); await loadBGPPeers(); }],
+    ['#tab-data', async () => { await loadInterfaces(); await loadFlows(); }],
+]);
+
+document.getElementById('app-tabs').addEventListener('shown.bs.tab', async (event) => {
+    const target = event.target.getAttribute('data-target');
+    const loader = tabLoaders.get(target);
+    if (loader) {
+        await loader();
+    }
+});
+
+checkSession();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,485 @@
+<!DOCTYPE html>
+<html lang="pt-br" data-bs-theme="dark">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>FlowGrid Console</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-3hK9EevWjGXogjHG6E8Qd38H9kspC5bGEMJXn2YgTh+z9U80qgzkGmHg56k97Ze3gSdz8sSU1yN1sEv0gY5xkw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <style>
+        body {
+            min-height: 100vh;
+            background: radial-gradient(circle at top, rgba(23, 162, 184, 0.25), transparent 60%), var(--bs-body-bg);
+        }
+        #app-view.d-none,
+        #login-view.d-none {
+            display: none !important;
+        }
+        .nav-pills .nav-link {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+        .nav-pills .nav-link i {
+            font-size: 1.1rem;
+        }
+        .tab-pane {
+            padding-top: 1.5rem;
+        }
+        .card-table {
+            max-height: 320px;
+            overflow: auto;
+        }
+        pre {
+            background-color: rgba(255,255,255,0.05);
+            border-radius: 0.75rem;
+            padding: 1rem;
+            max-height: 360px;
+            overflow: auto;
+        }
+    </style>
+</head>
+<body>
+    <div class="container py-5" id="login-view">
+        <div class="row justify-content-center">
+            <div class="col-md-6 col-lg-4">
+                <div class="card shadow border-0">
+                    <div class="card-body p-4">
+                        <div class="text-center mb-3">
+                            <i class="fa-solid fa-diagram-project fa-3x text-primary"></i>
+                            <h1 class="h4 mt-3">FlowGrid</h1>
+                            <p class="text-secondary">Autentique-se para acessar o painel</p>
+                        </div>
+                        <form id="login-form" novalidate>
+                            <div class="mb-3">
+                                <label for="login-user" class="form-label">Usuário</label>
+                                <input type="text" class="form-control" id="login-user" autocomplete="username" value="admin" required />
+                            </div>
+                            <div class="mb-3">
+                                <label for="login-pass" class="form-label">Senha</label>
+                                <input type="password" class="form-control" id="login-pass" autocomplete="current-password" required />
+                            </div>
+                            <button type="submit" class="btn btn-primary w-100">Entrar</button>
+                            <div class="form-text mt-3" id="login-feedback"></div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="container-fluid py-4 d-none" id="app-view">
+        <div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-3">
+            <div>
+                <h1 class="h3 mb-0">FlowGrid Console</h1>
+                <div class="text-secondary" id="session-info"></div>
+            </div>
+            <div class="d-flex gap-2 align-items-center">
+                <button class="btn btn-outline-secondary" id="refresh-all">
+                    <i class="fa-solid fa-rotate"></i>
+                    Atualizar
+                </button>
+                <button class="btn btn-outline-danger" id="logout-btn">
+                    <i class="fa-solid fa-arrow-right-from-bracket"></i>
+                    Sair
+                </button>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-lg-3">
+                <div class="card border-0 shadow-sm">
+                    <div class="card-body">
+                        <div class="nav flex-column nav-pills" id="app-tabs" role="tablist">
+                            <button class="nav-link active" data-bs-toggle="pill" data-target="#tab-dashboard" type="button" role="tab">
+                                <i class="fa-solid fa-chart-line"></i>Dashboard
+                            </button>
+                            <button class="nav-link" data-bs-toggle="pill" data-target="#tab-routers" type="button" role="tab">
+                                <i class="fa-solid fa-network-wired"></i>Roteadores & SNMP
+                            </button>
+                            <button class="nav-link" data-bs-toggle="pill" data-target="#tab-alerts" type="button" role="tab">
+                                <i class="fa-solid fa-bell"></i>Alertas
+                            </button>
+                            <button class="nav-link" data-bs-toggle="pill" data-target="#tab-config" type="button" role="tab">
+                                <i class="fa-solid fa-sliders"></i>Configuração
+                            </button>
+                            <button class="nav-link" data-bs-toggle="pill" data-target="#tab-whitelist" type="button" role="tab">
+                                <i class="fa-solid fa-shield"></i>Whitelist & Firewall
+                            </button>
+                            <button class="nav-link" data-bs-toggle="pill" data-target="#tab-management" type="button" role="tab">
+                                <i class="fa-solid fa-toolbox"></i>Administração
+                            </button>
+                            <button class="nav-link" data-bs-toggle="pill" data-target="#tab-data" type="button" role="tab">
+                                <i class="fa-solid fa-table"></i>Dados ao vivo
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-9">
+                <div class="card border-0 shadow-sm">
+                    <div class="card-body">
+                        <div class="tab-content" id="tab-content">
+                            <div class="tab-pane fade show active" id="tab-dashboard" role="tabpanel">
+                                <div class="row g-3" id="system-cards"></div>
+                                <div class="row g-3 mt-1">
+                                    <div class="col-lg-4">
+                                        <div class="card h-100">
+                                            <div class="card-body">
+                                                <h2 class="h5">Estatísticas Gerais</h2>
+                                                <dl class="row" id="stats-overview"></dl>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-4">
+                                        <div class="card h-100">
+                                            <div class="card-body">
+                                                <h2 class="h5">Top Fontes</h2>
+                                                <div class="card-table">
+                                                    <table class="table table-sm table-dark align-middle" id="top-sources-table">
+                                                        <thead>
+                                                            <tr>
+                                                                <th>Fonte</th>
+                                                                <th>Vendor</th>
+                                                                <th>Bytes</th>
+                                                                <th>%</th>
+                                                            </tr>
+                                                        </thead>
+                                                        <tbody></tbody>
+                                                    </table>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-4">
+                                        <div class="card h-100">
+                                            <div class="card-body">
+                                                <h2 class="h5">Top Aplicações</h2>
+                                                <div class="card-table">
+                                                    <table class="table table-sm table-dark align-middle" id="top-apps-table">
+                                                        <thead>
+                                                            <tr>
+                                                                <th>Proto</th>
+                                                                <th>Porta</th>
+                                                                <th>Bytes</th>
+                                                            </tr>
+                                                        </thead>
+                                                        <tbody></tbody>
+                                                    </table>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="tab-pane fade" id="tab-routers" role="tabpanel">
+                                <div class="row g-3">
+                                    <div class="col-12">
+                                        <div class="card">
+                                            <div class="card-body">
+                                                <div class="d-flex justify-content-between align-items-center mb-3">
+                                                    <h2 class="h5 mb-0">Roteadores configurados</h2>
+                                                    <button class="btn btn-outline-primary btn-sm" id="reload-routers"><i class="fa-solid fa-rotate"></i> Atualizar lista</button>
+                                                </div>
+                                                <div class="table-responsive card-table">
+                                                    <table class="table table-dark table-striped align-middle" id="routers-table">
+                                                        <thead>
+                                                            <tr>
+                                                                <th>Nome</th>
+                                                                <th>Vendor</th>
+                                                                <th>IP</th>
+                                                                <th>SNMP</th>
+                                                                <th>Ações</th>
+                                                            </tr>
+                                                        </thead>
+                                                        <tbody></tbody>
+                                                    </table>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-12">
+                                        <div class="card">
+                                            <div class="card-body">
+                                                <h2 class="h5">Adicionar Roteador</h2>
+                                                <form id="router-form" class="row g-3">
+                                                    <div class="col-md-4">
+                                                        <label class="form-label" for="router-name">Nome</label>
+                                                        <input class="form-control" id="router-name" required />
+                                                    </div>
+                                                    <div class="col-md-4">
+                                                        <label class="form-label" for="router-vendor">Vendor</label>
+                                                        <select class="form-select" id="router-vendor"></select>
+                                                    </div>
+                                                    <div class="col-md-4">
+                                                        <label class="form-label" for="router-ip">IP SNMP</label>
+                                                        <input class="form-control" id="router-ip" placeholder="192.0.2.1" required />
+                                                    </div>
+                                                    <div class="col-md-4">
+                                                        <label class="form-label" for="router-community">Community</label>
+                                                        <input class="form-control" id="router-community" value="public" />
+                                                    </div>
+                                                    <div class="col-md-4">
+                                                        <label class="form-label" for="router-port">Porta</label>
+                                                        <input class="form-control" id="router-port" type="number" value="161" min="1" max="65535" />
+                                                    </div>
+                                                    <div class="col-md-4">
+                                                        <label class="form-label" for="router-version">Versão</label>
+                                                        <select class="form-select" id="router-version">
+                                                            <option value="2c">SNMP v2c</option>
+                                                            <option value="3">SNMP v3</option>
+                                                        </select>
+                                                    </div>
+                                                    <div class="col-12 text-end">
+                                                        <button class="btn btn-primary" type="submit">Adicionar</button>
+                                                    </div>
+                                                </form>
+                                                <hr />
+                                                <h3 class="h6">Teste SNMP</h3>
+                                                <form id="snmp-test-form" class="row g-3">
+                                                    <div class="col-md-4"><input class="form-control" id="snmp-test-ip" placeholder="IP" required /></div>
+                                                    <div class="col-md-3"><input class="form-control" id="snmp-test-community" placeholder="Community" value="public" /></div>
+                                                    <div class="col-md-2"><input class="form-control" id="snmp-test-port" type="number" value="161" min="1" max="65535" /></div>
+                                                    <div class="col-md-3 text-end"><button class="btn btn-outline-light" type="submit">Executar</button></div>
+                                                </form>
+                                                <div class="form-text" id="snmp-test-result"></div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="tab-pane fade" id="tab-alerts" role="tabpanel">
+                                <div class="row g-3">
+                                    <div class="col-lg-7">
+                                        <div class="card h-100">
+                                            <div class="card-body">
+                                                <div class="d-flex justify-content-between align-items-center mb-3">
+                                                    <h2 class="h5 mb-0">Regras de alerta</h2>
+                                                    <button class="btn btn-outline-primary btn-sm" id="reload-alerts"><i class="fa-solid fa-rotate"></i> Atualizar</button>
+                                                </div>
+                                                <div class="card-table">
+                                                    <table class="table table-dark table-striped" id="alerts-table">
+                                                        <thead>
+                                                            <tr>
+                                                                <th>Nome</th>
+                                                                <th>Status</th>
+                                                                <th>Filtro</th>
+                                                                <th>Ações</th>
+                                                            </tr>
+                                                        </thead>
+                                                        <tbody></tbody>
+                                                    </table>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-5">
+                                        <div class="card h-100">
+                                            <div class="card-body">
+                                                <h2 class="h5">Nova Regra</h2>
+                                                <form id="alert-form" class="row g-3">
+                                                    <div class="col-12">
+                                                        <label class="form-label" for="alert-name">Nome</label>
+                                                        <input class="form-control" id="alert-name" required />
+                                                    </div>
+                                                    <div class="col-12">
+                                                        <label class="form-label" for="alert-filter">Filtro</label>
+                                                        <textarea class="form-control" id="alert-filter" rows="2" placeholder="DstPort=53"></textarea>
+                                                    </div>
+                                                    <div class="col-12">
+                                                        <label class="form-label" for="alert-condition">Condição</label>
+                                                        <input class="form-control" id="alert-condition" placeholder="bytes > 1000000" />
+                                                    </div>
+                                                    <div class="col-12">
+                                                        <label class="form-label" for="alert-window">Janela (segundos)</label>
+                                                        <input class="form-control" id="alert-window" type="number" value="60" min="1" />
+                                                    </div>
+                                                    <div class="col-12">
+                                                        <label class="form-label" for="alert-actions">Ações (separadas por vírgula)</label>
+                                                        <input class="form-control" id="alert-actions" placeholder="notify,block" />
+                                                    </div>
+                                                    <div class="col-12">
+                                                        <label class="form-label" for="alert-comment">Comentário</label>
+                                                        <textarea class="form-control" id="alert-comment" rows="2"></textarea>
+                                                    </div>
+                                                    <div class="col-12">
+                                                        <div class="form-check form-switch">
+                                                            <input class="form-check-input" type="checkbox" id="alert-enabled" checked />
+                                                            <label class="form-check-label" for="alert-enabled">Ativo</label>
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-12 text-end">
+                                                        <button class="btn btn-primary" type="submit">Criar Regra</button>
+                                                    </div>
+                                                </form>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="tab-pane fade" id="tab-config" role="tabpanel">
+                                <div class="row g-3">
+                                    <div class="col-12">
+                                        <div class="card">
+                                            <div class="card-body">
+                                                <div class="d-flex justify-content-between align-items-center mb-3">
+                                                    <h2 class="h5 mb-0">Configuração atual</h2>
+                                                    <button class="btn btn-outline-primary btn-sm" id="reload-config"><i class="fa-solid fa-rotate"></i> Recarregar</button>
+                                                </div>
+                                                <pre id="config-view"></pre>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-12">
+                                        <div class="card">
+                                            <div class="card-body">
+                                                <h2 class="h5">Atualizar configuração</h2>
+                                                <p class="text-secondary">Envie apenas os campos que deseja alterar (JSON válido).</p>
+                                                <textarea class="form-control" id="config-editor" rows="6" placeholder='{"netflow_port": 2055}'></textarea>
+                                                <div class="text-end mt-3">
+                                                    <button class="btn btn-primary" id="save-config">Aplicar</button>
+                                                </div>
+                                                <div class="form-text" id="config-feedback"></div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="tab-pane fade" id="tab-whitelist" role="tabpanel">
+                                <div class="row g-3">
+                                    <div class="col-md-6">
+                                        <div class="card h-100">
+                                            <div class="card-body">
+                                                <h2 class="h5">Whitelist atual</h2>
+                                                <pre id="whitelist-view"></pre>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <div class="card h-100">
+                                            <div class="card-body">
+                                                <h2 class="h5">Editar whitelist</h2>
+                                                <textarea class="form-control" id="whitelist-editor" rows="8" placeholder='{"ips": [], "cidrs": []}'></textarea>
+                                                <div class="text-end mt-3">
+                                                    <button class="btn btn-primary" id="save-whitelist">Salvar</button>
+                                                </div>
+                                                <div class="form-text" id="whitelist-feedback"></div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-12">
+                                        <div class="card">
+                                            <div class="card-body">
+                                                <h2 class="h5">Status do Firewall</h2>
+                                                <dl class="row" id="firewall-status"></dl>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="tab-pane fade" id="tab-management" role="tabpanel">
+                                <div class="row g-3">
+                                    <div class="col-lg-6">
+                                        <div class="card h-100">
+                                            <div class="card-body">
+                                                <h2 class="h5">Ações</h2>
+                                                <div class="d-grid gap-2">
+                                                    <button class="btn btn-outline-warning" data-action="/api/management/snmp-refresh">Atualizar SNMP</button>
+                                                    <button class="btn btn-outline-info" data-action="/api/management/cache-clear">Limpar caches</button>
+                                                    <button class="btn btn-outline-danger" data-action="/api/management/restart">Reiniciar serviço</button>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-6">
+                                        <div class="card h-100">
+                                            <div class="card-body">
+                                                <h2 class="h5">Dashboards Grafana</h2>
+                                                <ul class="list-group" id="grafana-list"></ul>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-12">
+                                        <div class="card">
+                                            <div class="card-body">
+                                                <h2 class="h5">Peers BGP</h2>
+                                                <div class="card-table">
+                                                    <table class="table table-dark table-striped" id="bgp-table">
+                                                        <thead>
+                                                            <tr>
+                                                                <th>Router</th>
+                                                                <th>Peer</th>
+                                                                <th>ASN</th>
+                                                                <th>Status</th>
+                                                            </tr>
+                                                        </thead>
+                                                        <tbody></tbody>
+                                                    </table>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="tab-pane fade" id="tab-data" role="tabpanel">
+                                <div class="row g-3">
+                                    <div class="col-md-6">
+                                        <div class="card">
+                                            <div class="card-body">
+                                                <h2 class="h5">Interfaces conhecidas</h2>
+                                                <div class="card-table">
+                                                    <table class="table table-dark table-striped" id="interfaces-table">
+                                                        <thead>
+                                                            <tr>
+                                                                <th>Dispositivo</th>
+                                                                <th>Interface</th>
+                                                                <th>Descrição</th>
+                                                            </tr>
+                                                        </thead>
+                                                        <tbody></tbody>
+                                                    </table>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <div class="card">
+                                            <div class="card-body">
+                                                <div class="d-flex justify-content-between align-items-center">
+                                                    <h2 class="h5">Flows recentes</h2>
+                                                    <div class="input-group input-group-sm" style="width: 160px;">
+                                                        <span class="input-group-text">Limite</span>
+                                                        <input type="number" class="form-control" id="flow-limit" value="20" min="1" max="500" />
+                                                    </div>
+                                                </div>
+                                                <div class="card-table">
+                                                    <table class="table table-dark table-striped" id="flows-table">
+                                                        <thead>
+                                                            <tr>
+                                                                <th>Fonte</th>
+                                                                <th>Src → Dst</th>
+                                                                <th>Proto/Porta</th>
+                                                                <th>Bytes</th>
+                                                                <th>Hora</th>
+                                                            </tr>
+                                                        </thead>
+                                                        <tbody></tbody>
+                                                    </table>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="toast-container position-fixed top-0 end-0 p-3" id="toast-container"></div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="assets/app.js" type="module"></script>
+</body>
+</html>

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -63,7 +63,15 @@ func (a *App) startHTTPServer() *http.Server {
 	mux.HandleFunc("/api/bgp/peers", a.authMiddleware(a.handleBGPPeers))
 
 	// frontend
-	mux.Handle("/", http.FileServer(http.Dir("./frontend")))
+	frontendFS := http.Dir("./frontend")
+	fileServer := http.FileServer(frontendFS)
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" || !strings.Contains(r.URL.Path, ".") {
+			http.ServeFile(w, r, "./frontend/index.html")
+			return
+		}
+		fileServer.ServeHTTP(w, r)
+	})
 
 	mux.HandleFunc("/flows", a.handleFlows)
 	mux.HandleFunc("/health", a.handleHealth)


### PR DESCRIPTION
## Summary
- add a new FlowGrid single-page frontend with authentication, dashboards and administrative panels backed by the existing Go APIs
- serve the SPA as the default route so the UI no longer requires navigating directly to individual .html files
- implement comprehensive client-side logic for fetching and updating routers, alerts, configuration, whitelist, management actions, Grafana dashboards, BGP peers, interfaces and recent flows

## Testing
- go test ./... *(hangs while building the module in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df272c965c8323b0a3ea7f7c347eba